### PR TITLE
Hyperlink and a default family selected as an example

### DIFF
--- a/R/a-helper.R
+++ b/R/a-helper.R
@@ -45,8 +45,6 @@ apply_filters <- function(data = austraits, input){
 }
 
 
-
-
 #' Find distinct values for a given variable
 #' @keywords internal
 extract_distinct_values <- function(data, var_name){
@@ -58,9 +56,9 @@ extract_distinct_values <- function(data, var_name){
     dplyr::pull()
 }
 
-#' Format relational database for display
+#' Format flattened database for display
 #' @keywords internal 
-#' @param database traits.build object
+#' @param database flattened traits.build object
 #' @importFrom tidyselect ends_with starts_with
 
 format_database_for_display <- function(database){
@@ -93,8 +91,27 @@ format_database_for_display <- function(database){
     ) |> 
     dplyr::relocate("dataset_id", .before = "taxon_name") |> 
     dplyr::relocate("source_primary_citation", .after = "method_context_properties") |> 
-    dplyr::relocate(c("genus", "family"), .after = "taxon_name") 
+    dplyr::relocate(c("genus", "family"), .after = "taxon_name")
 }
+
+#' Format hyperlinks in flattened database for display
+#' @keywords internal 
+#' @param database flattened traits.build object
+#' @importFrom tidyselect ends_with starts_with
+
+format_hyperlinks_for_display <- function(database){
+  database |> 
+  dplyr::mutate(
+    source_primary_citation_URL = str_match(source_primary_citation, "\\((https?://[^\\s)]+)\\)")[,2], # Extract URL
+    source_primary_citation = gsub("\\[([^]]+)\\]\\([^)]+\\)", "\\1", source_primary_citation), # Remove DOI MD link structure
+    source_primary_citation = gsub("_([^_]+)_", "<i>\\1</i>", source_primary_citation), # Replace MD italics with HTML italics
+    source_primary_citation = paste0('<a href="', source_primary_citation_URL, '" target="_blank">', source_primary_citation, '</a>') # Replaces the original source_primary_citation with an HTML version
+  ) |>
+  dplyr::select(
+    -source_primary_citation_URL
+  ) 
+}
+
 #' Retrieve all assets from a GitHub Release
 #'
 #' @param version_tag The version tag of the GitHub release (e.g., "6.0.0")

--- a/R/ui-server.R
+++ b/R/ui-server.R
@@ -28,7 +28,8 @@ austraits_ui <- function() {
           "Family" = "family",
           "Genus" = "genus",
           "Taxon name" = "taxon_name"
-        )
+        ),
+        selected = "family" 
       ),
 
       # Only show this panel if Taxon name is selected
@@ -59,7 +60,8 @@ austraits_ui <- function() {
         selectizeInput("family",
           label = "Family:",
           choices = NULL,
-          multiple = TRUE
+          multiple = TRUE, 
+          selected = "Fabaceae",
         )
       ),
       # Filter by trait information
@@ -223,7 +225,7 @@ austraits_server <- function(input, output, session) {
         session,
         "family",
         choices = family_choices(),
-        selected = NULL,
+        selected = "Fabaceae",
         server = TRUE
       )
     }


### PR DESCRIPTION
Towards #2 

Datatable is an HTML table.
In order for text to be hyperlinked, we need to do some HTML magic. 
In this PR, I have enabled datatable to render HTML tags if detected (`escape = FALSE`) 
I've developed another function: 
`format_hyperlinks_for_display` which will behind-the-scenes, take the source_primary_citation: 

1. Get rid of its Markdown formation for DOI and italics with regex
2. Extract the URLR from doi: field with regex
3. Write some html tags so the entire citation is hyperlinked and will open the doi URL into a new tab

Note that the source_primary_citation at this stage cannot be truncated...  the truncation conflicts with the html formatting. Something to consider. Are some fields that you want to hyperlink that also contain long text? If not, then I think we can leave as is. 

While I was hear, I also set Fabaceae as an example taxa, so it looks like we have data! 

