### PR TITLE
Refined clear locations to display full database

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -131,6 +131,10 @@ austraits_server <- function(input, output, session) {
     updateSelectizeInput(session, "lifestage", choices = all_age, server = TRUE)
     updateSelectizeInput(session, "apc_taxon_distribution", choices = all_states_territories, server = TRUE)
     
+    # Clear the radio button selection
+    updateRadioButtons(session, "location", selected = character(0))
+    updateRadioButtons(session, "taxon_rank", selected = character(0))
+
     # Store nothing in filtered_data()
     filtered_database(NULL)
     

--- a/R/server.R
+++ b/R/server.R
@@ -90,14 +90,32 @@ austraits_server <- function(input, output, session) {
       
       # Store filtered data into reactive value
       filtered_database(filtered_data)
-    } else {
+    } 
+    else {
       # No filters selected
-      filtered_database(NULL)
+      filtered_database()
     }
   })
   
   # Clear filters button action
   observeEvent(input$clear_filters, {
+    
+  # Check if any filters are currently applied
+  filters_applied <- !is.null(input$taxon_rank) || 
+                     !is.null(input$trait_name) || 
+                     !is.null(input$basis_of_record) || 
+                     !is.null(input$life_stage) || 
+                     !is.null(input$apc_taxon_distribution) || 
+                     !is.null(input$location)
+  
+  if (!filters_applied) {
+    # Show a notification if no filters are applied
+    showNotification("No filters are currently applied",
+                     type = "warning",
+                     duration = 3)
+    return() # Exit the observer early
+  }
+
     # Based on which filter is currently active
     if (input$taxon_rank == "taxon_name") {
       updateSelectizeInput(
@@ -136,7 +154,8 @@ austraits_server <- function(input, output, session) {
     updateRadioButtons(session, "taxon_rank", selected = character(0))
 
     # Set the filtered database to the full austraits dataset
-    filtered_database(NULL)
+    full_database <- austraits |> dplyr::collect()
+    filtered_database(full_database)
 
     # Reset the download data to NULL
   download_data_table <- reactive({

--- a/R/server.R
+++ b/R/server.R
@@ -128,16 +128,21 @@ austraits_server <- function(input, output, session) {
     # Clear the other filters that are not conditional
     updateSelectizeInput(session, "trait_name", choices = all_traits, server = TRUE)
     updateSelectizeInput(session, "basis_of_record", choices = all_bor, server = TRUE)
-    updateSelectizeInput(session, "lifestage", choices = all_age, server = TRUE)
+    updateSelectizeInput(session, "life_stage", choices = all_age, server = TRUE)
     updateSelectizeInput(session, "apc_taxon_distribution", choices = all_states_territories, server = TRUE)
     
     # Clear the radio button selection
     updateRadioButtons(session, "location", selected = character(0))
     updateRadioButtons(session, "taxon_rank", selected = character(0))
 
-    # Store nothing in filtered_data()
+    # Set the filtered database to the full austraits dataset
     filtered_database(NULL)
-    
+
+    # Reset the download data to NULL
+  download_data_table <- reactive({
+    NULL
+  })
+ 
     # Reset datatable filters
     if (!is.null(dt_proxy())) {
       DT::replaceData(dt_proxy(), display_data_table())
@@ -159,9 +164,6 @@ austraits_server <- function(input, output, session) {
     if (is.null(filtered_db)) {
       return(NULL)
     }
-    
-    
-    # browser()
     
     # Format the database for display
     format_database_for_display(filtered_db) |> 

--- a/R/server.R
+++ b/R/server.R
@@ -60,7 +60,7 @@ austraits_server <- function(input, output, session) {
   updateSelectizeInput(session, "life_stage", choices = all_age, server = TRUE)
   
   # Apply Filter
-  observeEvent(list(
+observeEvent(list(
     input$family,
     input$genus,
     input$taxon_name,
@@ -90,13 +90,28 @@ austraits_server <- function(input, output, session) {
       
       # Store filtered data into reactive value
       filtered_database(filtered_data)
-    } 
-    else {
+    } else {
       # No filters selected
-      filtered_database()
+      filtered_database(NULL)
     }
   })
-  
+    
+# Display all data when all taxa are selected
+  observeEvent(
+    input$taxon_rank, {
+    if(input$taxon_rank == "all") {
+      # If not taxonomic rank is selected, show full database
+      full_database <- austraits |> dplyr::collect()
+      filtered_database(full_database)
+    } 
+    else {
+      if (is.null(filtered_database())) {
+        return()
+      }
+    }
+  }
+) 
+
   # Clear filters button action
   observeEvent(input$clear_filters, {
     
@@ -153,14 +168,13 @@ austraits_server <- function(input, output, session) {
     updateRadioButtons(session, "location", selected = character(0))
     updateRadioButtons(session, "taxon_rank", selected = character(0))
 
-    # Set the filtered database to the full austraits dataset
-    full_database <- austraits |> dplyr::collect()
-    filtered_database(full_database)
+    # Set the filtered database to NULL
+    filtered_database(NULL)
 
     # Reset the download data to NULL
-  download_data_table <- reactive({
-    NULL
-  })
+    download_data_table <- reactive({
+      NULL
+    })
  
     # Reset datatable filters
     if (!is.null(dt_proxy())) {

--- a/R/ui.R
+++ b/R/ui.R
@@ -82,8 +82,8 @@ austraits_ui <- function() {
         label = "Filter by which location filter:",
         choices = c(
           "Georeferenced records" = "georeferenced",
-          "Enter coordinates" = "enter_coordinates",
-          "Recorded state/territory" = "state",
+          # "Enter coordinates" = "enter_coordinates",
+          # "Recorded state/territory" = "state",
           "APC taxon distribution" = "apc"
         ),
         selected = character(0) # No default selection

--- a/R/ui.R
+++ b/R/ui.R
@@ -25,6 +25,7 @@ austraits_ui <- function() {
       radioButtons("taxon_rank",
         label = "Filter by which taxon rank:",
         choices = c(
+          "All taxa" = "all",
           "Family" = "family",
           "Genus" = "genus",
           "Taxon name" = "taxon_name"


### PR DESCRIPTION
Contributes to #19 (disabling features not yet implemented) 

- State/territories and Coordinates are currently commented out from the locations filter

Clear filters: 

- Clear filters previously would display nothing in the datatable
- Some remnant filters were also selected too e.g "Family" for taxon rank despite there being nothing to be displayed
- Now improved features include: 
    - wiping all radiobuttons and selectize
    - load full austraits database into memory (should investigate caching for future usage for when clearing filters occur multiple times) 
    - warning for trying to clear filters after full database is loaded (previously, it would crap the app) 

Manual testing: 

- Downloads after clearing will download ALL of austraits
- Clearing will clear download handler
- Column filters function after clearing