### PR TITLE
Data table styling & truncation

### DIFF
--- a/.github/.gitignore
+++ b/.github/.gitignore
@@ -1,1 +1,2 @@
 *.html
+.vscode

--- a/.github/.gitignore
+++ b/.github/.gitignore
@@ -1,2 +1,1 @@
 *.html
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 austraits-6.0.0-flatten.parquet
 ignore/
+.vscode

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,12 @@ Authors@R:
              family = "Kar",
              role = "aut",
              email = "f.kar@unsw.edu.au",
-             comment = c(ORCID = "0000-0002-2760-3974"))
+             comment = c(ORCID = "0000-0002-2760-3974")),
+      person(given = "Eve",
+             family = "Miles",
+             role = "aut",
+             email = "e.miles@unsw.edu.au",
+             comment = c(ORCID = "0009-0008-4168-8645"))
              )
 Description: Shiny R package to the AusTraits Plant Traits database.
 License: CC BY 4.0 + file LICENSE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Authors@R:
              comment = c(ORCID = "0000-0002-2760-3974")),
       person(given = "Eve",
              family = "Miles",
-             role = "aut",
+             role = "ctb",
              email = "e.miles@unsw.edu.au",
              comment = c(ORCID = "0009-0008-4168-8645"))
              )

--- a/R/a-helper.R
+++ b/R/a-helper.R
@@ -142,7 +142,7 @@ format_hyperlinks_for_display <- function(database){
     source_primary_citation_URL = stringr::str_match(.data$source_primary_citation, "\\((https?://[^\\s)]+)\\)")[,2], # Extract URL
     source_primary_citation = gsub("\\[([^]]+)\\]\\([^)]+\\)", "\\1", .data$source_primary_citation), # Remove DOI MD link structure
     source_primary_citation = gsub("_([^_]+)_", "<i>\\1</i>", .data$source_primary_citation), # Replace MD italics with HTML italics
-    source_primary_citation = paste0('<a href="', .data$source_primary_citation_URL, '" target="_blank">', .data$source_primary_citation, '</a>') # Replaces the original source_primary_citation with an HTML version
+    source_primary_citation = paste0('<a href="', .data$source_primary_citation_URL, '" target="_blank">', stringr::str_trunc(.data$source_primary_citation, 30, "right"), '</a>') # Replaces the original source_primary_citation with a truncated HTML version
   ) |>
   dplyr::select(
     -"source_primary_citation_URL"

--- a/R/server.R
+++ b/R/server.R
@@ -241,13 +241,13 @@ observeEvent(list(
       return(datatable(data.frame(), options = list(pageLength = 10)))
     }
     
-    # Truncate text columns to 20 characters except for source_primary_citation
+    # Truncate text columns to 20 characters except for column names listed below
     display_data_truncated <- display_data
     text_columns <- sapply(display_data, is.character)
-    columns_to_exclude <- c("source_primary_citation")  # Exclude the hyperlink column from truncation
+    columns_to_exclude <- c("taxon_name", "trait_name", "genus", "family", "source_primary_citation")  # Exclude the hyperlink column from truncation
     
     for (col in names(display_data)[text_columns]) {
-      # Skip the source_primary_citation column
+      # Skip the excluded columns
       if (col %in% columns_to_exclude) next
       
       display_data_truncated[[col]] <- sapply(display_data[[col]], function(x) {
@@ -261,7 +261,7 @@ observeEvent(list(
     }
     # Determine column indices where we want to turn off column filtering
     no_filter_cols <- which(names(display_data_truncated) %in% c("value", "unit", "entity_type", "value_type", "replicates"))
-    
+    citation_col <- which(names(display_data_truncated) %in% c("source_primary_citation"))
     dt <- datatable(
       data = display_data_truncated,
       escape = FALSE,
@@ -269,16 +269,18 @@ observeEvent(list(
         pageLength = 10,
         scrollX = TRUE,
         searching = FALSE,
-        columnDefs = list(list(searchable = FALSE, 
-                               targets = no_filter_cols-1 # Targets denotes the columns index where filter will be switched off - Note that JS is 0 indexing
-        )
+        columnDefs = list(
+          list(
+            searchable = FALSE, 
+            targets = no_filter_cols-1 # Targets denotes the columns index where filter will be switched off - Note that JS is 0 indexing
+          )
         ),
         # Add server-side processing for better filtering performance
         serverSide = FALSE # Keep this as FALSE for client-side filtering to access filtered rows
       ),
       rownames = FALSE,
       filter = "top",
-      class = "cell-border stripe",
+      class = "cell-border stripe nowrap",
       # Removed selection = 'multiple' option
     )
     

--- a/R/server.R
+++ b/R/server.R
@@ -261,7 +261,8 @@ observeEvent(list(
     }
     # Determine column indices where we want to turn off column filtering
     no_filter_cols <- which(names(display_data_truncated) %in% c("value", "unit", "entity_type", "value_type", "replicates"))
-    citation_col <- which(names(display_data_truncated) %in% c("source_primary_citation"))
+    # Hide the row_id column
+    hide_cols <- which(names(display_data_truncated) %in% c("row_id"))
     dt <- datatable(
       data = display_data_truncated,
       escape = FALSE,
@@ -272,7 +273,11 @@ observeEvent(list(
         columnDefs = list(
           list(
             searchable = FALSE, 
-            targets = no_filter_cols-1 # Targets denotes the columns index where filter will be switched off - Note that JS is 0 indexing
+            targets = no_filter_cols - 1 # Targets denotes the columns index where filter will be switched off - Note that JS is 0 indexing
+          ),
+          list(
+            visible = FALSE,
+            targets = hide_cols - 1 # hide these columns from table view
           )
         ),
         # Add server-side processing for better filtering performance

--- a/R/server.R
+++ b/R/server.R
@@ -268,6 +268,7 @@ observeEvent(list(
       options = list(
         pageLength = 10,
         scrollX = TRUE,
+        searching = FALSE,
         columnDefs = list(list(searchable = FALSE, 
                                targets = no_filter_cols-1 # Targets denotes the columns index where filter will be switched off - Note that JS is 0 indexing
         )
@@ -277,7 +278,7 @@ observeEvent(list(
       ),
       rownames = FALSE,
       filter = "top",
-      class = "cell-border stripe"
+      class = "cell-border stripe",
       # Removed selection = 'multiple' option
     )
     


### PR DESCRIPTION
Closes #32

## Completed
- [X] All row heights are 1 line maximum
- [X] taxon_name, trait_name, genus and family are excluded from truncation
- [X] Removed top level search bar from table
- [X] Truncated citation URLs using ellipses
- [X] Excluded row_id from view in the table
- [X] Added myself as a contributor in the description

## Other Thoughts
- Thought about it more and a button to truncate / untruncate values probably isn't very necessary since we have the important values untruncated + the full data is downloadable anyways
- Would probably need a fair amount of conditional regex to truncate citation URLs to their proper shortened version (e.g. Name et al.) since the formatting is slightly different for some sources
 - Extra feature: potentially moving the table navigation at the bottom to outside the table / being sticky positioned - you have to scroll all the way down to change pages which is annoying for 50+ entries in one view
