### PR TITLE
App information Page

### DIFF
--- a/R/generate_usage_text.R
+++ b/R/generate_usage_text.R
@@ -27,7 +27,15 @@ generate_usage_and_citations_text <- function(data) {
 
   usage_text <- 
     sprintf(
-"Trait data is sourced from AusTraits %s (Falster et al. 2021, %s), drawing from contributions from the following datasets: %s. Taxa were aligned against the Australian Plant Census (APC, <https://biodiversity.org.au/nsl/services/search/taxonomy>) using the R package {APCalign} (Wenk et al 2024a), by first, searching for alignments with known names (via fuzzy matching), and then using known alignments to update taxon names to the latest. Original taxon names attributed by the data collectors are included. Trait names were harmonised against the AusTraits Plant Dictionary (APD) (Wenk et al 2024b). Note that trait values were scored at different levels (individual, population or species), according to source; individual and population level values might not be representative of the trait values displayed by a species in other parts of its range. The full dataset is available at [doi: %s](http://doi.org/%s) and is made available under the CC BY 4.0 license (<https://creativecommons.org/licenses/by/4.0/>). The data is provided 'as is' without any warranties or guarantees of any kind.
+"The AusTraits dataset is available at [doi: %s](http://doi.org/%s). AusTraits data is distributed under the CC BY 4.0 license (<https://creativecommons.org/licenses/by/4.0/>). The data is provided 'as is' without any warranties or guarantees of any kind. The AusTraits database is described in Falster et al. 2021, %s, drawing from many the contributed datasets. Publications using AusTraits data should cite the AusTraits data paper and relevant datasets.
+
+Taxa were aligned against the Australian Plant Census (APC, <https://biodiversity.org.au/nsl/services/search/taxonomy>) using the R package {APCalign} (Wenk et al 2024a), by first, searching for alignments with known names (via exact, then fuzzy matching), and then using known alignments to update taxon names to the currently accepted name. Original taxon names attributed by the data collectors are included. 
+
+Trait names were harmonised against the AusTraits Plant Dictionary (APD) (Wenk et al 2024b). 
+
+Note that trait values were scored at different levels (individual, population or species), according to source; individual and population level values might not be representative of the trait values displayed by a species in other parts of its range. The full dataset is available at [doi: %s](http://doi.org/%s)
+
+The following datasets contributed data included in the selected search: %s
   
 References
 

--- a/R/mod_app_info.R
+++ b/R/mod_app_info.R
@@ -73,17 +73,17 @@ profile_links <- function(github = NULL, orcid = NULL) {
         tags$a(href = "https://doi.org/10.5281/zenodo.3568417", target = "_blank", "Zenodo"),
         " as an .rds or .json file."),
       
-      p("This portal is also a place to acknowledge all the ", tags$a(href = "https://doi.org/10.5281/zenodo.3568417", target = "_blank", "researchers and contributors"), " who have shared their data with AusTraits. We thank them for their contributions."),
+      p("The Zenodo repository lists all ", tags$a(href = "https://doi.org/10.5281/zenodo.3568417", target = "_blank", "researchers"), " who have contributed their data to AusTraits. We thank them for being part of this project."),
       
       p("Additional AusTraits Project outputs to wrangle and interpret the data include:"),
       tags$ul(
-        tags$li(tags$a(href = "https://github.com/traitecoevo/austraits", target = "_blank", "Austraits"), " - an R package to explore and wrangle the AusTraits Database"),
+        tags$li(tags$a(href = "https://github.com/traitecoevo/austraits", target = "_blank", "austraits"), " - an R package to explore and wrangle the AusTraits Database"),
         tags$li(tags$a(href = "https://github.com/traitecoevo/APD", target = "_blank", "AusTraits Plant Dictionary"),
           " \u2013 formal definitions of all traits included in the database")
       ),
       
       p("Please visit our ", tags$a(href = "https://www.austraits.org", target = "_blank", "website"), " for more project information."),
-      p("Exciting work is being done using AusTraits data across plant ecology, functional traits research, and biodiversity informatics, from predicting species responses to climate change to understanding ecosystem dynamics at a continental scale. ",),
+      p("The AusTraits database is facilitating research on Australia's diverse flora, including functional traits research, the preservation of Australia's unique plants, predicting species' responses to climate change, and understanding ecosystem dynamics at a continental scale. ",),
       
       tags$hr(),
 
@@ -97,25 +97,27 @@ profile_links <- function(github = NULL, orcid = NULL) {
       ),
       
       p(tags$strong("Dataset type \u2014"),
-        "Raw data or Species averages? Raw data has every individual observation measurement wheras Species averages roll observations into species-level summaries (mean, min, max, median). ",
+        "Raw data or Species averages? Raw data has the individual observations submitted by contributors while Species averages presents species-level summary statistics (mean, min, max, median for numeric traits and value summaries for categorical traits). ",
         "Pick based on the question you're asking."),
       
       p(tags$strong("Taxonomy \u2014"),
-        "Choose a rank - All taxa, Family, Genus, or Taxon name, and select from the dropdown that appears. ",
-        "Family (Fabaceae) is selected by default as a starting point."),
+        "Choose a taxonomic filter - Select All taxa or Family, Genus, or Taxon name (species and infraspecies), then select from the dropdown that appears. ",
+        "Family (Fabaceae) is selected as the default starting point."),
       
       p(tags$strong("Traits \u2014"),
-        "Search or browse the trait dropdown \u2013 you can select more than one at a time. ",
-        "Switch to ", tags$strong("Trait features"), " if you want to narrow things down by grouping, structure, or keywords.",
-        "Recommended to either use Trait name or Trait features at a time."),
+        "Search or browse the trait dropdown \u2013 noting you can select multiple traits at a time. ",
+        "Switch to ", tags$strong("Trait features"), " if you want to search by trait groupings, measured structures, or keywords.",
+        "Enabling trait features filters also refines the trait selection in the dropdown menu, for easier searching."),
+        "Note, Trait features is only enabled if a trait name is not yet selected."
       
       p(tags$strong("Location \u2014"),
-        tags$strong("APC taxon distribution"), " (state/territory) works for both datasets. ",
-        tags$strong("Georeferenced records"), " with a bounding box is raw data only. Useful for zooming into a specific region of Australia for individual observations."),
+        "Data can be filtered by taxon distribution (per the APC) or by observation coordinates. You can opt to display all georeferenced data or specify a bounding box, filtering to data collected within a specific region of Australia.",
+        "The", tags$strong("APC taxon distribution"), " (state/territory) filter works for both raw data and species average data outputs, while the ",
+        tags$strong("Georeferenced records"), " option is only enabled for when Raw data are displayed."),
       
       p(tags$strong("Custom filters \u2014"),
-        "Layer up to three extra filters on top of everything else. ",
-        "Each new slot appears once the one before it has values, allowing multi-level hierarchical filtering. Please use" , tags$strong("|"), "between two free-text filter querys to multi-select "),
+        "Add up to three additional column filters to fine-tune the data displayed.",
+        "An additional filter slot appears once you've filled in a column name and values for the first filter. Columns with a controlled vocabulary (e.g. ", tags$strong("life_stage"), " have a drop-down menu of allowed options, while other columns (e.g. ", tags$strong("context property"), " accept any text. Please use" , tags$strong("|"), "between two free-text filter querys to multi-select. "),
       
       p(tags$strong("Data Preview \u2014"),
         "Your filtered results, viewable 10, 25, 50, or 100 rows at a time. Columns are sortable."),
@@ -126,25 +128,8 @@ profile_links <- function(github = NULL, orcid = NULL) {
       tags$h4(style = hdr, "Usage Guidelines"),
       
       p(tags$strong("Citing AusTraits \u2014"),
-        "If you use data from this portal in a publication or report, please cite both the AusTraits Database and the ",
-        "original source datasets. The ", tags$strong("Citations"), " tab lists all relevant references for your current ",
-        "selection \u2013 grab them before you download."),
-      
-      p(tags$strong("Suggested acknowledgment \u2014"),
-        tags$em("\"Data used in this study were obtained from the AusTraits Database (https://www.austraits.org).\""),
-        " Tailor this to fit your context."),
-      
-      p(tags$strong("BibTeX export \u2014"),
-        "Download also lets you download a .bib file. Drop it straight into LaTeX or import into ",
-        "most reference managers."),
-      
-      p(tags$strong("Redistribution \u2014"),
-        "AusTraits data is freely available for research and educational use. ",
-        "If you share or reuse the data, please include clear attribution to the AusTraits Database and a link to this portal."),
-      
-      p(tags$strong("Commercial use \u2014"),
-        "For any enquiries around commercial use of AusTraits data, please reach out via the ",
-        tags$a(href = "https://www.austraits.org", target = "_blank", "AusTraits website"), "."),
+        "The ", tags$strong("Citations"), " tab indicates the proper attribution for your selected AusTraits data. ",
+        "original source datasets.
       
       p(tags$strong("Feedback \u2014"),
         "Something off? A suggestion bubbling up? We're always keen to hear from people using the portal. ",

--- a/R/mod_app_info.R
+++ b/R/mod_app_info.R
@@ -10,30 +10,162 @@
 mod_app_info_ui <- function(id){
   ns <- NS(id)
   
+profile_links <- function(github = NULL, orcid = NULL) {
+    tagList(
+      if (!is.null(github)) tags$a(href = github, target = "_blank",
+        tags$i(class = "fa-brands fa-github", style = "color: #24292e; font-size: 0.85em;"),
+        title = "GitHub",
+        style = "text-decoration: none;"),
+      if (!is.null(orcid)) tags$a(href = orcid, target = "_blank",
+        tags$i(class = "fa-brands fa-orcid", style = "color: #A6CE39; font-size: 0.85em;"),
+        title = "ORCID",
+        style = "margin-left: 5px; text-decoration: none;")
+    )
+  }
+  
+  # Reusable section header style
+  hdr <- "color: #1565c0; border-bottom: 2px solid #2196f3; padding-bottom: 6px; margin-top: 7px; margin-bottom: 14px;"
+  
   card(
-    card_header("How to Use the App"),
+    card_header("About & Information"),
     card_body(
-      p("This application allows users to filter and explore the AusTraits dataset."),
-      p("Use the sidebar to apply filters based on taxonomy, traits, location, and additional criteria."),
-      p("Filtered data will be displayed in the 'Data Preview' tab."),
-      p("You can download the filtered data using the 'Download displayed data' button."),
-      tags$a(href = "https://www.austraits.org", target = "_blank", "AusTraits Website")
+      # ATTRIBUTION
+      tags$h4(style = hdr, "Attribution"),
+      
+      p("The AusTraits Database Portal was designed by ",
+        tags$strong("Pushkal Garg"), " ", profile_links(github = "https://github.com/Pushkalgithub", orcid = "https://orcid.org/0009-0002-0179-2946"), ", ",
+        tags$strong("Fonti Kar"), " ", profile_links(github = "https://github.com/fontikar", orcid = "https://orcid.org/0000-0002-2760-3974"), ", ",
+        tags$strong("Daniel Falster"), " ", profile_links(github = "https://github.com/dfalster", orcid = "https://orcid.org/0000-0002-9814-092X"), ", ",
+        tags$strong("Elizabeth Wenk"), " ", profile_links(github = "https://github.com/ehwenk", orcid = "https://orcid.org/0000-0001-5640-5910"), ", and ",
+        tags$strong("Ray Miles"), " ", profile_links(github = "https://github.com/raymiles"), "."
+      ),
+      
+      p("The AusTraits Database and design of this portal are supported by an UNSW Research Infrastructure Grant ",
+        "and Australian Research Data Commons co-investment. ",
+        "The ARDC is enabled by the Australian Government's National Collaborative Research Infrastructure Strategy (NCRIS)."),
+      
+      tags$style(".logo-link img { transition: transform 0.2s ease, opacity 0.2s ease; }
+                  .logo-link img:hover { transform: scale(1.08); opacity: 0.75; cursor: pointer; }"),
+      
+      tags$div(
+        style = "display: flex; gap: 24px; align-items: center; justify-content: center; padding: 24px 0; flex-wrap: wrap;",
+        tags$a(href = "https://www.austraits.org", target = "_blank", class = "logo-link",
+          tags$img(src = "https://austraits.org/images/austraits_hex.png", height = "70px", alt = "AUSTRAITS", style = "max-width: 140px;")),
+        tags$a(href = "https://www.unsw.edu.au", target = "_blank", class = "logo-link",
+          tags$img(src = "https://austraits.org/images/UNSW.png", height = "70px", alt = "UNSW")),
+        tags$a(href = "https://www.wsu.edu.au", target = "_blank", class = "logo-link",
+          tags$img(src = "https://upload.wikimedia.org/wikipedia/en/f/f0/Western_Sydney_University_Crest.png", height = "70px", alt = "Western Sydney University", style = "max-width: 140px;")),
+        tags$a(href = "https://www.botanicgardens.org.au", target = "_blank", class = "logo-link",
+          tags$img(src = "https://austraits.org/images/RBG.png", height = "70px", alt = "Royal Botanic Garden Sydney", style = "max-width: 140px;")),
+        tags$a(href = "https://ardc.edu.au", target = "_blank", class = "logo-link",
+          tags$img(src = "https://austraits.org/images/ARDC2.png", height = "70px", alt = "ARDC")),
+        tags$a(href = "https://www.education.gov.au/ncris", target = "_blank", class = "logo-link",
+          tags$img(src = "https://bioplatforms.com/wp-content/uploads/2024/03/afb87787085b2b5c5a7814a28971e5aa-1.png", height = "70px", alt = "NCRIS", style = "max-width: 140px;"))
+      ),
+            
+      tags$hr(),
+      
+      # BACKGROUND
+      tags$h4(style = hdr, "Background"),
+      
+      p("The AusTraits Database Portal offers a web-based interface to filter, view and download subsets of the AusTraits Database. ",
+        "The full database can also be downloaded from ",
+        tags$a(href = "https://doi.org/10.5281/zenodo.3568417", target = "_blank", "Zenodo"),
+        " as an .rds or .json file."),
+      
+      p("This portal is also a place to acknowledge all the ", tags$a(href = "https://doi.org/10.5281/zenodo.3568417", target = "_blank", "researchers and contributors"), " who have shared their data with AusTraits. We thank them for their contributions."),
+      
+      p("Additional AusTraits Project outputs to wrangle and interpret the data include:"),
+      tags$ul(
+        tags$li(tags$a(href = "https://github.com/traitecoevo/austraits", target = "_blank", "Austraits"), " - an R package to explore and wrangle the AusTraits Database"),
+        tags$li(tags$a(href = "https://github.com/traitecoevo/APD", target = "_blank", "AusTraits Plant Dictionary"),
+          " \u2013 formal definitions of all traits included in the database")
+      ),
+      
+      p("Please visit our ", tags$a(href = "https://www.austraits.org", target = "_blank", "website"), " for more project information."),
+      p("Exciting work is being done using AusTraits data across plant ecology, functional traits research, and biodiversity informatics, from predicting species responses to climate change to understanding ecosystem dynamics at a continental scale. ",),
+      
+      tags$hr(),
+
+      # HOW TO USE
+      tags$h4(style = hdr, "How to Use"),
+      
+      tags$div(
+        style = "background: #e3f2fd; border-left: 4px solid #2196f3; padding: 10px 15px; border-radius: 4px; margin-bottom: 18px;",
+        tags$strong("Quick start:"),
+        " Select a dataset type \u2192 set your taxonomy \u2192 pick a trait (optional) \u2192 explore."
+      ),
+      
+      p(tags$strong("Dataset type \u2014"),
+        "Raw data or Species averages? Raw data has every individual observation measurement wheras Species averages roll observations into species-level summaries (mean, min, max, median). ",
+        "Pick based on the question you're asking."),
+      
+      p(tags$strong("Taxonomy \u2014"),
+        "Choose a rank - All taxa, Family, Genus, or Taxon name, and select from the dropdown that appears. ",
+        "Family (Fabaceae) is selected by default as a starting point."),
+      
+      p(tags$strong("Traits \u2014"),
+        "Search or browse the trait dropdown \u2013 you can select more than one at a time. ",
+        "Switch to ", tags$strong("Trait features"), " if you want to narrow things down by grouping, structure, or keywords.",
+        "Recommended to either use Trait name or Trait features at a time."),
+      
+      p(tags$strong("Location \u2014"),
+        tags$strong("APC taxon distribution"), " (state/territory) works for both datasets. ",
+        tags$strong("Georeferenced records"), " with a bounding box is raw data only. Useful for zooming into a specific region of Australia for individual observations."),
+      
+      p(tags$strong("Custom filters \u2014"),
+        "Layer up to three extra filters on top of everything else. ",
+        "Each new slot appears once the one before it has values, allowing multi-level hierarchical filtering. Please use" , tags$strong("|"), "between two free-text filter querys to multi-select "),
+      
+      p(tags$strong("Data Preview \u2014"),
+        "Your filtered results, viewable 10, 25, 50, or 100 rows at a time. Columns are sortable."),
+      
+      tags$hr(),
+      
+      # USAGE GUIDELINES
+      tags$h4(style = hdr, "Usage Guidelines"),
+      
+      p(tags$strong("Citing AusTraits \u2014"),
+        "If you use data from this portal in a publication or report, please cite both the AusTraits Database and the ",
+        "original source datasets. The ", tags$strong("Citations"), " tab lists all relevant references for your current ",
+        "selection \u2013 grab them before you download."),
+      
+      p(tags$strong("Suggested acknowledgment \u2014"),
+        tags$em("\"Data used in this study were obtained from the AusTraits Database (https://www.austraits.org).\""),
+        " Tailor this to fit your context."),
+      
+      p(tags$strong("BibTeX export \u2014"),
+        "Download also lets you download a .bib file. Drop it straight into LaTeX or import into ",
+        "most reference managers."),
+      
+      p(tags$strong("Redistribution \u2014"),
+        "AusTraits data is freely available for research and educational use. ",
+        "If you share or reuse the data, please include clear attribution to the AusTraits Database and a link to this portal."),
+      
+      p(tags$strong("Commercial use \u2014"),
+        "For any enquiries around commercial use of AusTraits data, please reach out via the ",
+        tags$a(href = "https://www.austraits.org", target = "_blank", "AusTraits website"), "."),
+      
+      p(tags$strong("Feedback \u2014"),
+        "Something off? A suggestion bubbling up? We're always keen to hear from people using the portal. ",
+        "Get in touch through the ", tags$a(href = "https://www.austraits.org", target = "_blank", "AusTraits website"), ".")
+      
     )
   )
 }
-    
+
 #' app_info Server Functions
 #'
 #' @noRd 
 mod_app_info_server <- function(id){
   moduleServer(id, function(input, output, session){
     ns <- session$ns
-    # No server logic needed - just static content
+    # No server logic needed — static content
   })
 }
-    
+
 ## To be copied in the UI
 # mod_app_info_ui("app_info_1")
-    
+
 ## To be copied in the server
 # mod_app_info_server("app_info_1")


### PR DESCRIPTION
**Updated App Information tab**

Closes #88 

- Overhauled the App Information section with proper content and structure.
- Added How to Use guide covering dataset switching, taxonomy and trait filters, location filters, custom filters, data preview, trait view, taxon view and citations. 
- Added Attribution section with GitHub and ORCID profile links for all contributors, and proper ARDC/NCRIS acknowledgment text. Logo placeholders added for UNSW, Western Sydney University, Royal Botanic Garden Sydney and ARDC , clickable with hover effects, ready for final logo URLs. 
- Expanded Background section with links to Zenodo, the austraits R package and AusTraits Plant Dictionary. 
- Added Usage Guidelines covering citation, BibTeX export, redistribution and feedback.