### PR TITLE
docs: add cross-package pointer to austraits-meta

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,25 @@
+# austraits.portal — agent guide
+
+> ⚠️ **Package-local guidance is TODO.** This stub currently only points to family-wide
+> context. Add austraits.portal-specific architecture, build/test commands, and gotchas below.
+
+## Cross-package context
+
+`austraits.portal` is part of the **AusTraits family**. Cross-package concerns are documented
+centrally in the **[austraits-meta](https://github.com/traitecoevo/austraits-meta)** repo —
+don't restate them here, read them there:
+
+- **Start with [`AGENTS.md`](https://github.com/traitecoevo/austraits-meta/blob/main/AGENTS.md)** —
+  pipeline order, who owns what, dependency direction, cross-boundary artifacts, source-of-truth
+  rules, gotchas.
+- **[`dependencies.yml`](https://github.com/traitecoevo/austraits-meta/blob/main/dependencies.yml)** —
+  machine-readable package graph + artifacts.
+- **[`governance/`](https://github.com/traitecoevo/austraits-meta/tree/main/governance)** —
+  label taxonomy, board #9 conventions, release playbooks, triage.
+
+> austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against
+> the actual repos.
+
+## Package-local guidance (TODO)
+
+_To be written: austraits.portal-specific architecture, key entry points, build & test, known gotchas._

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,25 +1,9 @@
-# austraits.portal — agent guide
+# CLAUDE.md
 
-> ⚠️ **Package-local guidance is TODO.** This stub currently only points to family-wide
-> context. Add austraits.portal-specific architecture, build/test commands, and gotchas below.
+This repo keeps its agent & contributor guidance in **[`AGENTS.md`](../AGENTS.md)** so the same
+content is tool-agnostic and shared across every agent.
 
-## Cross-package context
+**👉 Read [`AGENTS.md`](../AGENTS.md)** for repo-local orientation (architecture, build & test,
+gotchas) and the AusTraits-family cross-package pointer.
 
-`austraits.portal` is part of the **AusTraits family**. Cross-package concerns are documented
-centrally in the **[austraits-meta](https://github.com/traitecoevo/austraits-meta)** repo —
-don't restate them here, read them there:
-
-- **Start with [`AGENTS.md`](https://github.com/traitecoevo/austraits-meta/blob/main/AGENTS.md)** —
-  pipeline order, who owns what, dependency direction, cross-boundary artifacts, source-of-truth
-  rules, gotchas.
-- **[`dependencies.yml`](https://github.com/traitecoevo/austraits-meta/blob/main/dependencies.yml)** —
-  machine-readable package graph + artifacts.
-- **[`governance/`](https://github.com/traitecoevo/austraits-meta/tree/main/governance)** —
-  label taxonomy, board #9 conventions, release playbooks, triage.
-
-> austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against
-> the actual repos.
-
-## Package-local guidance (TODO)
-
-_To be written: austraits.portal-specific architecture, key entry points, build & test, known gotchas._
+Don't duplicate that content here — edit `AGENTS.md` and this file stays correct by reference.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# austraits.portal — agent & contributor guide
+
+`austraits.portal` is an R package providing a **Shiny interface to the AusTraits Plant Traits
+database** — a code-free web portal for exploring and downloading trait data, deployed at
+<https://unsw.shinyapps.io/austraits-portal/>.
+
+## Repo-local guidance
+
+- **App entry point:** `app.R` runs `pkgload::load_all(".")` then
+  `shiny::shinyApp(ui = app_ui, server = app_server)`. The top-level UI/server live in
+  `R/app_ui.R` and `R/app_server.R`.
+- **Modular Shiny (golem-style):** functionality is split into `mod_*` modules (e.g.
+  `mod_filters`, `mod_data_table`, `mod_taxon_view`, `mod_trait_view`, `mod_citations`,
+  `mod_app_info`), `fct_*` business logic (`fct_filter_parsing`, `fct_filter_application`,
+  `fct_prepare_data`), `srv_*` server helpers, and `utils_*` helpers — all under `R/`.
+- **Data layer:** trait data is stored as Parquet and queried via DuckDB/Arrow. Bundled data
+  lives in `inst/extdata/austraits/` — a small `austraits-5.0.0-lite` set ships in the repo; the
+  `austraits-7.0.0-full` set is prepared locally (see README "Data Preparation").
+- **Data prep:** `prepare_data_for_portal()` (in `R/fct_prepare_data.R`) flattens the AusTraits
+  database, computes species averages, exports Parquet, and caches metadata/dropdowns.
+- **Config:** `config.yml` (via the `config` package); deployment manifest in `manifest.json`.
+- **Tests:** `tests/testthat/` (testthat edition 3) + `spelling`; see `tests/TEST_COVERAGE.md`.
+
+Dev follows the standard R-package workflow plus a Shiny launch step: `devtools::load_all()` /
+`pkgload::load_all()`, then `shiny::shinyApp(ui = app_ui, server = app_server)` (or just source
+`app.R`); `devtools::test()`; `devtools::check()`. Default development branch is `develop`.
+
+> Heads-up: the app needs prepared data files to run — only the `lite` set is in the repo, so a
+> fresh checkout shows the demo subset until you build the full set. Deployment to shinyapps.io
+> (`rsconnect::deployApp()`) requires `austraits.portal` itself to be installed from GitHub first
+> (`remotes::install_github("traitecoevo/austraits.portal@develop")`) and dependencies tracked in
+> `manifest.json` (`rsconnect::writeManifest()`).
+
+---
+
+## AusTraits family — cross-package context
+
+`austraits.portal` is part of the **AusTraits family** (a subset of the
+[`traitecoevo`](https://github.com/traitecoevo) org) — here, the AusTraits web portal (interactive
+data exploration/access). Family-wide concerns are documented centrally in
+**[austraits-meta](https://github.com/traitecoevo/austraits-meta)** — don't restate them here, read
+them there:
+
+- **Start with [`AGENTS.md`](https://github.com/traitecoevo/austraits-meta/blob/main/AGENTS.md)** —
+  pipeline order, who owns what, dependency direction, source-of-truth rules, cross-boundary
+  artifacts, gotchas.
+- **[`dependencies.yml`](https://github.com/traitecoevo/austraits-meta/blob/main/dependencies.yml)** —
+  machine-readable package graph + cross-boundary artifacts.
+- **[`governance/`](https://github.com/traitecoevo/austraits-meta/tree/main/governance)** —
+  label taxonomy, board #9 conventions, release playbooks, triage.
+
+**Filing issues:** the whole family is tracked on one board,
+[AusTraits #9](https://github.com/orgs/traitecoevo/projects/9) (new issues auto-add to it). Follow
+the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob/main/governance/issue-guide.md):
+pick one work-type label (`bug` / `task` / `epic`); Status and Priority are set on the board, not as
+labels.
+
+> austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against the
+> actual repos.

--- a/README.Rmd
+++ b/README.Rmd
@@ -199,3 +199,15 @@ The app supports deep linking via URL query parameters:
 - `?tab=Trait+View`
 - All filter states can be encoded in URLs for sharing
 
+## AusTraits family
+
+`austraits.portal` is part of the **AusTraits family** of packages maintained by the
+[AusTraits](https://austraits.org) team. See **[austraits.org](https://austraits.org)** for the
+project, the data, and the people behind it.
+
+Contributing? Issues across the family are tracked on one board,
+[AusTraits #9](https://github.com/orgs/traitecoevo/projects/9), and new issues are auto-added. Please
+read the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob/main/governance/issue-guide.md)
+in [`austraits-meta`](https://github.com/traitecoevo/austraits-meta) — the family's cross-package
+knowledge and governance hub — before filing.
+

--- a/README.md
+++ b/README.md
@@ -220,3 +220,15 @@ Displayed in real-time on App Information tab
 The app supports deep linking via URL query parameters: -
 `?taxon_name=Eucalyptus+globulus` - `?trait_name=leaf_area` -
 `?tab=Trait+View` - All filter states can be encoded in URLs for sharing
+
+## AusTraits family
+
+`austraits.portal` is part of the **AusTraits family** of packages maintained by the
+[AusTraits](https://austraits.org) team. See **[austraits.org](https://austraits.org)** for the
+project, the data, and the people behind it.
+
+Contributing? Issues across the family are tracked on one board,
+[AusTraits #9](https://github.com/orgs/traitecoevo/projects/9), and new issues are auto-added. Please
+read the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob/main/governance/issue-guide.md)
+in [`austraits-meta`](https://github.com/traitecoevo/austraits-meta) — the family's cross-package
+knowledge and governance hub — before filing.


### PR DESCRIPTION
Adds the **AusTraits family** cross-package pointer to this repo, following the
[`austraits-meta`](https://github.com/traitecoevo/austraits-meta) convention.

**Structure (CLAUDE.md is a stub; AGENTS.md holds the content):**
- `.claude/CLAUDE.md` — short stub that defers to `AGENTS.md`.
- `AGENTS.md` — repo-local guidance (architecture, build & test, gotchas) **plus** an *AusTraits
  family* section pointing to austraits-meta (`AGENTS.md`, `dependencies.yml`, `governance/`) and the
  issue/board #9 guide.
- README — an *AusTraits family* section (→ [austraits.org](https://austraits.org) for the
  project/team; → austraits-meta `governance/issue-guide.md` + board #9 for contributing).

Package-local guidance is seeded from `DESCRIPTION`/`README`; cross-package concerns are linked, not
restated. Part of bootstrapping `austraits-meta`. Opened as **draft** for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)