### PR TITLE
ci: auto-add new issues to AusTraits board #9

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/traitecoevo/projects/9
-          github-token: ${{ secrets.ADD_TO_PROJECT }}
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,12 @@
+name: Add new issues to AusTraits board #9
+on:
+  issues:
+    types: [opened]
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/traitecoevo/projects/9
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/traitecoevo/projects/9
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ secrets.ADD_TO_PROJECT }}


### PR DESCRIPTION
Adds `.github/workflows/add-to-project.yml` so new issues in this repo auto-add to [board #9](https://github.com/orgs/traitecoevo/projects/9).

⚠️ **Prerequisite:** set an org secret `ADD_TO_PROJECT_PAT` (a token with Projects read/write) **before merging** — without it the workflow run on a new issue fails (Actions tab only; blocks nothing). The workflow triggers on `issues: opened` only, so it does not run on this PR.

Details + token setup: `austraits-meta/governance/auto-add-to-board.md`. Opened as **draft**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)