### PR TITLE
Fix footer never rendering, and layout overflow on narrow screens

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -124,14 +124,6 @@ tags$head(
       "AusTraits Data Portal"
     ),
 
-    footer =  tags$footer(
-      "Powered by ",
-      tags$a(href = "https://www.unsw.edu.au/science", target = "_blank", "UNSW Faculty of Science"), 
-      align = "right", style = "padding: 30px",
-      
-      div("Created by AusTraits Team",  
-          target)
-      ),
     # Create a sidebar for the app
     sidebar = mod_filters_ui("filters"),
 
@@ -158,6 +150,19 @@ tags$head(
       nav_panel(
         title = "Citations",
         mod_citations_ui("citations")
+      ),
+
+      # Note: the footer belongs on navset_bar, not page_sidebar —
+      # page_sidebar() has no `footer` argument, so passing one there is
+      # silently swallowed as an HTML attribute and never renders.
+      footer = tags$footer(
+        "Powered by ",
+        tags$a(href = "https://www.unsw.edu.au/science", target = "_blank",
+               "UNSW Faculty of Science"),
+        align = "right", style = "padding: 30px",
+
+        div("Created by AusTraits Team",
+            target)
       )
     )
   )

--- a/inst/www/austraits-portal.css
+++ b/inst/www/austraits-portal.css
@@ -102,6 +102,14 @@ a:hover {
   border-bottom-color: var(--at-green);
 }
 
+/* bslib gives `.bslib-page-main` a 576px min-width, which the sidebar grid
+   cell cannot honour on narrow screens — the tab bar and content then spill
+   past the right edge. The portal is embedded in an iframe on austraits.org,
+   so let the main region shrink with its cell instead. */
+.bslib-page-main {
+  min-width: 0 !important;
+}
+
 /* --- Headings -----------------------------------------------------------*/
 h1, h2, .content h2 {
   color: var(--at-green-dark);


### PR DESCRIPTION
Two defects on the deployed portal, found while restyling `APCalign-app` to match this app.

### The footer has never rendered

`page_sidebar()` has no `footer` argument, so `footer = tags$footer(...)` fell into `...`, htmltools coerced it to an HTML attribute, and it was dropped. You can see this on the live site today: <https://app.austraits.org/austraits/> serves zero `<footer>` elements, no "Powered by" text, and a stray `footer=` attribute in the HTML.

`navset_bar()` does accept a footer, so it moves there.

### The layout overflows below ~900px

bslib sets `min-width: 576px` on `.bslib-page-main`, which the sidebar's grid cell cannot honour once the sidebar takes its share — the tab bar and content spill past the right edge. This matters because the portal is embedded in an iframe on [austraits.org/portal.html](https://austraits.org/portal.html). The stylesheet now lets the main region shrink with its cell.

### Verification

Ran the app locally and measured at 1440 / 820 / 600px: the footer renders at every width, the tab bar stays inside the viewport, and there are no page errors. `devtools::test()` gives 182 pass, 0 fail, 21 pre-existing skips.

### Related

The same two fixes are in the [`APCalign-app` restyle](https://github.com/traitecoevo/APCalign-app), which copied this app's UI construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)