### PR TITLE
fix: add develop to CI trigger

### DIFF
--- a/.github/workflows/rcmd-check.yml
+++ b/.github/workflows/rcmd-check.yml
@@ -2,7 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, develop]
   pull_request:
     branches: [main, master, develop]
 


### PR DESCRIPTION
### Changes
- Updated `.github/workflows/rcmd-check.yml` to include `develop` in push branches trigger